### PR TITLE
Fixed the parameter used in the exception constructor

### DIFF
--- a/Source/Blueberry.Desktop.WindowsApp.Bluetooth/DnaBluetoothLEAdvertisementWatcher.cs
+++ b/Source/Blueberry.Desktop.WindowsApp.Bluetooth/DnaBluetoothLEAdvertisementWatcher.cs
@@ -340,7 +340,7 @@ namespace Blueberry.Desktop.WindowsApp.Bluetooth
             // Null guard
             if (device == null)
                 // TODO: Localize
-                throw new ArgumentNullException("Failed to get information about the Bluetooth device");
+                throw new ArgumentException("Failed to get the Bluetooth device from the specified ID.", nameof(deviceId));
 
             // If we are already paired...
             if (device.DeviceInformation.Pairing.IsPaired)


### PR DESCRIPTION
I fixed the parameter used, as the first parameter in an ArgumentNullException is the parameter name, not a message. I also changed to an ArgumentException as an ArgumentNullException is only used when the argument itself is null.